### PR TITLE
Remove newrelic extension requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=5.5",
         "ext-swoole": "^4.0",
-        "ext-newrelic": ">=3.0.5.95",
+        "killmails/polyfill-newrelic": "^1.0",
         "upscale/swoole-reflection": "^1.3"
     },
     "autoload": {


### PR DESCRIPTION
newrelic extension should not be a requirement for development. Instead of forcing developers to have newrelic extension on their development environment, I've added polyfill package to not throw errors.