### PR TITLE
Allow installation of swoole-reflection version  2.0 and 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": ">=7.1",
         "ext-swoole": "^4.0",
         "ext-newrelic": ">=3.0.5.95",
-        "upscale/swoole-reflection": "^1.3"
+        "upscale/swoole-reflection": "^1.3|^2.0|^3.0"
     },
     "autoload": {
         "psr-4": {"Upscale\\Swoole\\Newrelic\\": "src/"}


### PR DESCRIPTION
The current version of swoole-newrelic only allows installation of the 1.0 version, this pull request adds support for the other two versions.